### PR TITLE
Pass through an AppIniter func to be able to launch chains with different apps

### DIFF
--- a/testing/app.go
+++ b/testing/app.go
@@ -27,7 +27,9 @@ import (
 	"github.com/cosmos/ibc-go/v3/testing/simapp"
 )
 
-var DefaultTestingAppInit func() (TestingApp, map[string]json.RawMessage) = SetupTestingApp
+type AppIniter func() (TestingApp, map[string]json.RawMessage)
+
+var DefaultTestingAppInit AppIniter = SetupTestingApp
 
 type TestingApp interface {
 	abci.Application
@@ -58,8 +60,8 @@ func SetupTestingApp() (TestingApp, map[string]json.RawMessage) {
 // that also act as delegators. For simplicity, each validator is bonded with a delegation
 // of one consensus engine unit (10^6) in the default token of the simapp from first genesis
 // account. A Nop logger is set in SimApp.
-func SetupWithGenesisValSet(t *testing.T, valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, chainID string, powerReduction sdk.Int, balances ...banktypes.Balance) TestingApp {
-	app, genesisState := DefaultTestingAppInit()
+func SetupWithGenesisValSet(t *testing.T, appIniter AppIniter, valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, chainID string, powerReduction sdk.Int, balances ...banktypes.Balance) TestingApp {
+	app, genesisState := appIniter()
 
 	// set genesis accounts
 	authGenesis := authtypes.NewGenesisState(authtypes.DefaultParams(), genAccs)

--- a/testing/chain.go
+++ b/testing/chain.go
@@ -119,6 +119,7 @@ func NewTestChainWithValSet(t *testing.T, coord *Coordinator, chainID string, va
 		senderAccs = append(senderAccs, senderAcc)
 	}
 
+	// TODO: test commit, delete me
 	app := SetupWithGenesisValSet(t, valSet, genAccs, chainID, sdk.DefaultPowerReduction, genBals...)
 
 	// create current header and call begin block

--- a/testing/chain.go
+++ b/testing/chain.go
@@ -91,7 +91,7 @@ type TestChain struct {
 //
 // CONTRACT: Validator array must be provided in the order expected by Tendermint.
 // i.e. sorted first by power and then lexicographically by address.
-func NewTestChainWithValSet(t *testing.T, coord *Coordinator, chainID string, valSet *tmtypes.ValidatorSet, signers map[string]tmtypes.PrivValidator) *TestChain {
+func NewTestChainWithValSet(t *testing.T, coord *Coordinator, appIniter AppIniter, chainID string, valSet *tmtypes.ValidatorSet, signers map[string]tmtypes.PrivValidator) *TestChain {
 	genAccs := []authtypes.GenesisAccount{}
 	genBals := []banktypes.Balance{}
 	senderAccs := []SenderAccount{}
@@ -119,8 +119,7 @@ func NewTestChainWithValSet(t *testing.T, coord *Coordinator, chainID string, va
 		senderAccs = append(senderAccs, senderAcc)
 	}
 
-	// TODO: test commit, delete me
-	app := SetupWithGenesisValSet(t, valSet, genAccs, chainID, sdk.DefaultPowerReduction, genBals...)
+	app := SetupWithGenesisValSet(t, appIniter, valSet, genAccs, chainID, sdk.DefaultPowerReduction, genBals...)
 
 	// create current header and call begin block
 	header := tmproto.Header{
@@ -156,7 +155,7 @@ func NewTestChainWithValSet(t *testing.T, coord *Coordinator, chainID string, va
 
 // NewTestChain initializes a new test chain with a default of 4 validators
 // Use this function if the tests do not need custom control over the validator set
-func NewTestChain(t *testing.T, coord *Coordinator, chainID string) *TestChain {
+func NewTestChain(t *testing.T, coord *Coordinator, appIniter AppIniter, chainID string) *TestChain {
 	// generate validators private/public key
 	var (
 		validatorsPerChain = 4
@@ -177,7 +176,7 @@ func NewTestChain(t *testing.T, coord *Coordinator, chainID string) *TestChain {
 	// or, if equal, by address lexical order
 	valSet := tmtypes.NewValidatorSet(validators)
 
-	return NewTestChainWithValSet(t, coord, chainID, valSet, signersByAddress)
+	return NewTestChainWithValSet(t, coord, appIniter, chainID, valSet, signersByAddress)
 }
 
 // GetContext returns the current context for the application.

--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -35,7 +35,7 @@ func NewCoordinator(t *testing.T, n int) *Coordinator {
 
 	for i := 1; i <= n; i++ {
 		chainID := GetChainID(i)
-		chains[chainID] = NewTestChain(t, coord, chainID)
+		chains[chainID] = NewTestChain(t, coord, DefaultTestingAppInit, chainID)
 	}
 	coord.Chains = chains
 

--- a/testing/coordinator.go
+++ b/testing/coordinator.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	ChainIDPrefix   = "testchain"
-	globalStartTime = time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
+	GlobalStartTime = time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC)
 	TimeIncrement   = time.Second * 5
 )
 
@@ -30,7 +30,7 @@ func NewCoordinator(t *testing.T, n int) *Coordinator {
 	chains := make(map[string]*TestChain)
 	coord := &Coordinator{
 		T:           t,
-		CurrentTime: globalStartTime,
+		CurrentTime: GlobalStartTime,
 	}
 
 	for i := 1; i <= n; i++ {


### PR DESCRIPTION
## Issues

Partially tackles

- https://github.com/cosmos/interchain-security/issues/58

Related to

- https://github.com/cosmos/interchain-security/issues/59
- https://github.com/cosmos/interchain-security/issues/77

## Overview

There is a goal to split provider/consumer apps so that people can build from a minimal viable consumer chain. This PR is paired with [another PR in cosmos/interchain-security](https://github.com/cosmos/interchain-security/pull/84). The two PR's together

1. Split the app.go into two app.go's. One for parent and child.
2. Modify ibc-go testing to be able to use two different app.go's.

Therefore this PR should be merged together with 

- https://github.com/cosmos/interchain-security/pull/84


---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/ibc-go/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
